### PR TITLE
Improve rendering performance by using virtual dom

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,5 @@
 import {run} from '@cycle/xstream-run';
 import {makeDOMDriver, pre, div, h, input, button, span} from '@cycle/dom';
-import eachCons from 'each-cons';
 import _ from 'lodash';
 import Terminal from 'terminal.js';
 import TerminalHTMLOutput from 'terminal.js/lib/output/html';
@@ -389,7 +388,7 @@ function addSegment (state) {
     );
   }
 
-  state.currentSegment = ''
+  state.currentSegment = '';
 
   return state;
 }
@@ -512,7 +511,7 @@ function sanitizeSendKeys (keyToSend) {
   }
 
   if (keyToSend === ';') {
-    return '"\\\\;"'
+    return '"\\\\;"';
   }
 
   const charactersToSanitize = [

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function createWindow () {
     socket.send('%update-binds ' + childProcess.execSync('tmux list-keys').toString('utf-8'));
 
     socket.on('message', (message) => {
-      console.log('received:', message);
+      //console.log('received:', message);
       tmux.stdin.write(message + '\n');
     });
 
@@ -39,7 +39,7 @@ function createWindow () {
 
     tmux.stdout.on('data', (data) => {
       data = data.toString('utf8')
-      console.log('tmux:', data);
+      //console.log('tmux:', data);
 
       socket.send(data);
     });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@cycle/xstream-run": "^3.1.0",
     "bufferutil": "^1.2.1",
     "cors": "^2.8.0",
-    "each-cons": "^1.0.0",
     "electron": "^1.3.5",
     "express": "^4.14.0",
     "lodash": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@cycle/xstream-run": "^3.1.0",
     "bufferutil": "^1.2.1",
     "cors": "^2.8.0",
+    "each-cons": "^1.0.0",
     "electron": "^1.3.5",
     "express": "^4.14.0",
     "lodash": "^4.15.0",

--- a/static/styles.css
+++ b/static/styles.css
@@ -19,7 +19,7 @@ pre {
   line-height: 20px;
 }
 
-pre>div {
+.terminal-line {
   margin: -1px 0px;
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -45,3 +45,23 @@ webview {
   width: 100%;
   height: 100%;
 }
+
+.cursor {
+  background: pink;
+  color: black;
+  animation: hueRotate 1s linear 0s infinite;
+}
+
+@keyframes hueRotate {
+  from {
+    -webkit-filter: hue-rotate(0deg);
+  }
+
+  50% {
+    -webkit-filter: hue-rotate(180deg);
+  }
+
+  to {
+    -webkit-filter: hue-rotate(360deg);
+  }
+}


### PR DESCRIPTION
My ghetto test was to scroll through client.js in fullscreen neovim on a
1080p monitor.

Previously, using terminal.js toString('html'), I got 1 - 2fps. Now, we
get 20 - 30fps.

This will close #6
- [x] make the cursor show up
